### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/build_check_deploy.yaml
+++ b/.github/workflows/build_check_deploy.yaml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Publish to Registry
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: docker.pkg.github.com/isee/iseeworkshop2020/iseeworkshop2020:latest
           username: ${{ github.actor }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore